### PR TITLE
Remove app role

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -6,7 +6,6 @@
   - role: nginx
   - role: node
   - role: redis
-  - role: app
   - role: postgresql
   - role: rbenv
   - role: sidekiq

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -1,5 +1,0 @@
-- name: Add application directory
-  file: dest=/var/www/rails_app state=directory owner=webadm group=www-data mode=0700
-  become: yes
-  become_user: root
-  tags: app

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -6,7 +6,6 @@
   - role: nginx
   - role: node
   - role: redis
-  - role: app
   - role: postgresql
   - role: rbenv
   - role: sidekiq


### PR DESCRIPTION
Application directory is already added in `roles/nginx/tasks/main.yml` with proper permissions. `app` role overrides it with improper permissions. So deleting `app` role.

This fixes nginx 'Permission denied" issue.
